### PR TITLE
Pin the babel-core peer dependency to 6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "source-map-support": "^0.4.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.4.x"
+    "babel-core": "6.4.x"
   },
   "bin": {
     "babel-watch": "./babel-watch.js"


### PR DESCRIPTION
`babel-core@6.6` introduced a change to the `OptionManager.prototype.mergeOptions` API: it accepts an options object now.

A potential fix for this is to pin the dependency for `babel-core` to `6.4.x`, without the caret.
