### PR TITLE
Update babel-core to latest minor version.

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -285,7 +285,11 @@ function compile(filename, callback) {
   const optsManager = new babel.OptionManager;
 
   // merge in base options and resolve all the plugins and presets relative to this file
-  optsManager.mergeOptions(transformOpts, 'base', null, path.dirname(filename));
+  optsManager.mergeOptions({
+    options: transformOpts,
+    alias: 'base',
+    loc: path.dirname(filename)
+  });
 
   const opts = optsManager.init({ filename });
   // Do not process config files since has already been done with the OptionManager

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "source-map-support": "^0.4.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.4.x"
+    "babel-core": "^6.7.x"
   },
   "bin": {
     "babel-watch": "./babel-watch.js"


### PR DESCRIPTION
`babel-core@6.6` introduced a change to the OptionManager.prototype.mergeOptions API: it accepts an options object now.

This fixes the usage of the aforementioned API.

There may be other changes to the API that I haven't discovered yet. I just fixed what I needed to get my projects working.

I submitted #9 for a quick fix, in case @kmagiera would like to make sure we are 100% compatible with `babel-core@^6.7.x`.
