### PR TITLE
When using -D, app should restart on all watched file changed

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -149,7 +149,7 @@ function handleChange(file) {
   delete cache[absoluteFile];
   delete errors[absoluteFile];
 
-  if (requiredFiles[absoluteFile] || hadErrors) {
+  if (program.disableAutowatch || requiredFiles[absoluteFile] || hadErrors) {
     // file is in use by the app, let's restart!
     restartApp();
   }


### PR DESCRIPTION
We are using generated json file in our project, however currently when these files are changed, babel-watch won't restart automatically even already set disableAutowatch to true.
