### PR TITLE
add debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# vscode
+# not sure if you want my settings committed to your repo
+.vscode

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 `babel-watch` was made to be compatible with `babel-node` and `nodemon` options. Not all of them are supported yet, here is a short list of supported command line options:
 
 ```
+    -d, --debug [port]             Start debugger on port
     -o, --only [globs]             Matching files will be transpiled
     -i, --ignore [globs]           Matching files will not be transpiled
     -e, --extensions [extensions]  List of extensions to hook into [.es6,.js,.es,.jsx]
@@ -67,6 +68,12 @@ When you want your app not to restart automatically for some set of files, you c
 
 ```bash
   babel-watch --exclude templates app.js
+```
+
+Start the debugger
+
+```bash
+  babel-watch app.js --debug 5858
 ```
 
 ## Demo

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -245,12 +245,13 @@ function restartApp() {
     }
   }
 
-  // If debugger mode is present 
-  if(program.debug) {
-      //Set an unused port number for child process.
-      process.execArgv.push('--debug=' + (program.debug));
+  // Support for --debug option
+  const runnerExecArgv = process.execArgv.slice();
+  if (program.debug) {
+    runnerExecArgv.push('--debug=' + program.debug);
   }
-  const app = fork(path.resolve(__dirname, 'runner.js'));
+
+  const app = fork(path.resolve(__dirname, 'runner.js'), { execArgv: runnerExecArgv });
 
   app.on('message', (data) => {
     const filename = data.filename;

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -21,7 +21,7 @@ function collect(val, memo) {
   return memo;
 }
 
-program.option('d, --debug [port]', 'Set debugger port')
+program.option('-d, --debug [port]', 'Set debugger port')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -21,6 +21,7 @@ function collect(val, memo) {
   return memo;
 }
 
+program.option('d, --debug [port]', 'Set debugger port')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');
@@ -244,6 +245,11 @@ function restartApp() {
     }
   }
 
+  // If debugger mode is present 
+  if(program.debug) {
+      //Set an unused port number for child process.
+      process.execArgv.push('--debug=' + (program.debug));
+  }
   const app = fork(path.resolve(__dirname, 'runner.js'));
 
   app.on('message', (data) => {


### PR DESCRIPTION
This is the start of adding debugger support to `babel-watch`. We should probably add more options in the future.
## Usage

`babel-watch app.js --debug 5858`

This will start a debugger running on the specified port only on the child process. Im using vscode for my debugging and it works great for me. 

Should allow #18 to move forward.  I know it doesnt support all the debugger options, but its enough for me. 😸 
