### PR TITLE
Add support for --inspect and --debug-brk

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 
 ```
     -d, --debug [port]             Start debugger on port
+    -D, --debug-brk                Enable debug break mode
+    -I, --inspect                  Enable inspect mode
     -o, --only [globs]             Matching files will be transpiled
     -i, --ignore [globs]           Matching files will not be transpiled
     -e, --extensions [extensions]  List of extensions to hook into [.es6,.js,.es,.jsx]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 
 ```
     -d, --debug [port]             Start debugger on port
-    -D, --debug-brk                Enable debug break mode
+    -B, --debug-brk                Enable debug break mode
     -I, --inspect                  Enable inspect mode
     -o, --only [globs]             Matching files will be transpiled
     -i, --ignore [globs]           Matching files will not be transpiled

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -22,7 +22,7 @@ function collect(val, memo) {
 }
 
 program.option('-d, --debug [port]', 'Set debugger port')
-program.option('-D, --debug-brk', 'Enable debug break mode')
+program.option('-B, --debug-brk', 'Enable debug break mode')
 program.option('-I, --inspect', 'Enable inspect mode')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -22,8 +22,8 @@ function collect(val, memo) {
 }
 
 program.option('-d, --debug [port]', 'Set debugger port')
-program.option('-I, --inspect', 'Enable inspect mode')
 program.option('-D, --debug-brk', 'Enable debug break mode')
+program.option('-I, --inspect', 'Enable inspect mode')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -22,6 +22,8 @@ function collect(val, memo) {
 }
 
 program.option('-d, --debug [port]', 'Set debugger port')
+program.option('-I, --inspect', 'Enable inspect mode')
+program.option('-D, --debug-brk', 'Enable debug break mode')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');
@@ -249,6 +251,14 @@ function restartApp() {
   const runnerExecArgv = process.execArgv.slice();
   if (program.debug) {
     runnerExecArgv.push('--debug=' + program.debug);
+  }
+  // Support for --inspect option
+  if (program.inspect) {
+    runnerExecArgv.push('--inspect');
+  }
+  // Support for --debug-brk
+  if(program.debugBrk) {
+    runnerExecArgv.push('--debug-brk');
   }
 
   const app = fork(path.resolve(__dirname, 'runner.js'), { execArgv: runnerExecArgv });


### PR DESCRIPTION
`babel-watch script.js -IB`

```bash
Debugger listening on port 9229.
Warning: This is an experimental feature and could change at any time.
To start debugging, open the following URL in Chrome:
    chrome-devtools://devtools/remote/serve_file/@60cd6e859b9f557d2312f5bf532f6aec5f284980/inspector.html?experiments=true&v8only=true&ws=localhost:9229/node
```