### PR TITLE
Add delay option and support for unknown options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
     -p, --plugins [string]
     -b, --presets [string]
     -w, --watch [dir]              Watch directory "dir" or files. Use once for each directory or file to watch
-        --delay <n>                The amount of time in milliseconds to wait before emitting an "update" event after a change. default: 1000
+        --delay <n>                The amount of time in milliseconds to wait before emitting an "update" event after a change. default: 100
     -x, --exclude [dir]            Exclude matching directory/files from watcher. Use once for each directory or file.
     -L, --use-polling              In some filesystems watch events may not work correcly. This option enables "polling" which should mitigate this type of issues
     -D, --disable-autowatch        Don't automatically start watching changes in files "required" by the program

--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 `babel-watch` was made to be compatible with `babel-node` and `nodemon` options. Not all of them are supported yet, here is a short list of supported command line options:
 
 ```
-    -d, --debug [port]             Start debugger on port
-    -B, --debug-brk                Enable debug break mode
-    -I, --inspect                  Enable inspect mode
     -o, --only [globs]             Matching files will be transpiled
     -i, --ignore [globs]           Matching files will not be transpiled
     -e, --extensions [extensions]  List of extensions to hook into [.es6,.js,.es,.jsx]
     -p, --plugins [string]
     -b, --presets [string]
     -w, --watch [dir]              Watch directory "dir" or files. Use once for each directory or file to watch
+        --delay <n>                The amount of time in milliseconds to wait before emitting an "update" event after a change. default: 1000
     -x, --exclude [dir]            Exclude matching directory/files from watcher. Use once for each directory or file.
     -L, --use-polling              In some filesystems watch events may not work correcly. This option enables "polling" which should mitigate this type of issues
     -D, --disable-autowatch        Don't automatically start watching changes in files "required" by the program
     -H, --disable-ex-handler       Disable source-map-enhanced uncaught exception handler. (you may want to use this option in case your app registers a custom uncaught exception handler)
 ```
+
+Unknown options will be passed to node process.
 
 While the `babel-watch` process is running you may type "rs" and hit return in the terminal to force reload the app.
 

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -145,14 +145,11 @@ stdin.on('data', (data) => {
 
 function handleChange(file) {
   const absoluteFile = file.startsWith('/') ? file : path.join(cwd, file);
-  const hadErrors = (errors[absoluteFile] !== undefined);
   delete cache[absoluteFile];
   delete errors[absoluteFile];
 
-  if (program.disableAutowatch || requiredFiles[absoluteFile] || hadErrors) {
-    // file is in use by the app, let's restart!
-    restartApp();
-  }
+  // file is in use by the app, let's restart!
+  restartApp();
 }
 
 function generateTempFilename() {

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -146,11 +146,14 @@ stdin.on('data', (data) => {
 
 function handleChange(file) {
   const absoluteFile = file.startsWith('/') ? file : path.join(cwd, file);
+  const hadErrors = (errors[absoluteFile] !== undefined);
   delete cache[absoluteFile];
   delete errors[absoluteFile];
 
-  // file is in use by the app, let's restart!
-  restartApp();
+  if (program.disableAutowatch || requiredFiles[absoluteFile] || hadErrors) {
+    // file is in use by the app, let's restart!
+    restartApp();
+  }
 }
 
 function generateTempFilename() {

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -27,7 +27,7 @@ program.option('-e, --extensions [extensions]', 'List of extensions to hook into
 program.option('-p, --plugins [string]', '', babel.util.list);
 program.option('-b, --presets [string]', '', babel.util.list);
 program.option('-w, --watch [dir]', 'Watch directory "dir" or files. Use once for each directory or file to watch', collect, []);
-program.option('--delay <n>', 'The amount of time in milliseconds to wait before emitting an "update" event after a change. default: 1000', parseInt);
+program.option('--delay <n>', 'The amount of time in milliseconds to wait before emitting an "update" event after a change. default: 100', parseInt);
 program.option('-x, --exclude [dir]', 'Exclude matching directory/files from watcher. Use once for each directory or file.', collect, []);
 program.option('-L, --use-polling', 'In some filesystems watch events may not work correcly. This option enables "polling" which should mitigate this type of issues');
 program.option('-D, --disable-autowatch', 'Don\'t automatically start watching changes in files "required" by the program');
@@ -316,13 +316,13 @@ function restartAppInternal() {
   childApp = app;
 }
 
-const delay = program.delay || 1000;
+const delay = program.delay || 100;
 let timeout;
 function restartApp() {
   if (timeout) {
     clearTimeout(timeout);
   }
-  timeout = setTimeout(function() {
+  timeout = setTimeout(() => {
     timeout = null;
     restartAppImmediate();
   }, delay);


### PR DESCRIPTION
We are using babel-watch in our project and found there are several problems.
I'm sorry that I make this all-in-one PR. 

Changes:
  - Prevent restart on compilation errors
  - Add `delay` option in order to delay restarting when multiple files changed at the same time (use lodash/debounce). 
  - <del>Support node harmony flag (especially useful when using node 7 async/await)</del>
  - Pass all unknown options to node process, e.g. `--debug`, `--harmony`, and even `--inspect` or `--debug-brk`
