### PR TITLE
Use fs.closeSync and fs.unlinkSync to avoid deprecated async warning …

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -200,10 +200,10 @@ function killApp() {
     const currentPipeFilename = pipeFilename;
     childApp.on('exit', () => {
       if (currentPipeFd) {
-        fs.close(currentPipeFd); // silently close pipe fd - ignore callback
+        fs.closeSync(currentPipeFd); // silently close pipe fd
       }
       if (currentPipeFilename) {
-        fs.unlink(currentPipeFilename); // silently remove old pipe file - ignore callback
+        fs.unlinkSync(currentPipeFilename); // silently remove old pipe file
       }
       restartAppInternal();
     });


### PR DESCRIPTION
Is there a reason closeSync & unlinkSync aren't being used here, rather than their async brethren (which give the async warning)?

If not, then this ought to remove that pesky warning!