### PR TITLE
Change async version of fs.close & fs.unlink to sync versions

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -200,10 +200,10 @@ function killApp() {
     const currentPipeFilename = pipeFilename;
     childApp.on('exit', () => {
       if (currentPipeFd) {
-        fs.close(currentPipeFd); // silently close pipe fd - ignore callback
+        fs.closeSync(currentPipeFd);
       }
       if (currentPipeFilename) {
-        fs.unlink(currentPipeFilename); // silently remove old pipe file - ignore callback
+        fs.unlinkSync(currentPipeFilename);
       }
       restartAppInternal();
     });


### PR DESCRIPTION
Node v7.* fires a deprecation warning for async node methods without callbacks. This is triggered when a node app is restarted with babel-watch.

`DeprecationWarning: Calling an asynchronous function without callback is deprecated.`

Changed the `fs.close` & `fs.unlink` to synchronous versions