### PR TITLE
Changes SIGINT exit code to 0 to remove errors on user interruption.

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -117,7 +117,7 @@ let watcherInitialized = (program.watch.length === 0);
 
 process.on('SIGINT', function() {
   watcher.close();
-  process.exit(1);
+  process.exit(0);
 });
 
 watcher.on('change', handleChange);


### PR DESCRIPTION
Reference Issue: https://github.com/kmagiera/babel-watch/issues/63

I am currently receiving the following error when terminating babel-watch with <kbd>CTRL</kbd>+<kbd>C</kbd>

This is happening because SIGINT is exiting the process with a failure. I don't think this is necessary since SIGINT is a user-initiated signal.

**terminal output**
```bash
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-ssr-boilerplate@1.0.0 serve:watch: `cross-env NODE_ENV=development babel-watch server/development.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the react-ssr-boilerplate@1.0.0 serve:watch script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/nmcl54/.npm/_logs/2017-08-07T06_09_19_750Z-debug.log
```