### PR TITLE
Allow binding to host/port for --inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 ```
     -d, --debug [port]             Start debugger on port
     -B, --debug-brk                Enable debug break mode
-    -I, --inspect                  Enable inspect mode
+    -I, --inspect [port]           Enable inspect mode
     -o, --only [globs]             Matching files will be transpiled
     -i, --ignore [globs]           Matching files will not be transpiled
     -e, --extensions [extensions]  List of extensions to hook into [.es6,.js,.es,.jsx]

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -23,7 +23,7 @@ function collect(val, memo) {
 
 program.option('-d, --debug [port]', 'Set debugger port')
 program.option('-B, --debug-brk', 'Enable debug break mode')
-program.option('-I, --inspect', 'Enable inspect mode')
+program.option('-I, --inspect [port]', 'Enable inspect mode')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');
@@ -266,7 +266,8 @@ function restartAppInternal() {
   }
   // Support for --inspect option
   if (program.inspect) {
-    runnerExecArgv.push('--inspect');
+    const inspectArg = typeof program.inspect === 'string' ? '=' + program.inspect : '';
+    runnerExecArgv.push('--inspect' + inspectArg);
   }
   // Support for --debug-brk
   if(program.debugBrk) {


### PR DESCRIPTION
Just as `--debug` takes an optional port, I'd like to `--inspect` do the same.

I'm running most of my work in containers, and even remote on other servers, and being able to bind to something else than the default `127.0.0.1:9226` would be nice.

Let me know if something else should be changed, for this to get through.