### PR TITLE
Fix race condition between onmessage and onexit

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -197,15 +197,16 @@ function handleFileLoad(filename, callback) {
 
 function killApp() {
   if (childApp) {
-    const currentPipeFd = pipeFd;
-    const currentPipeFilename = pipeFilename;
     childApp.on('exit', () => {
-      if (currentPipeFd) {
-        fs.closeSync(currentPipeFd); // silently close pipe fd
+      if (pipeFd) {
+        fs.closeSync(pipeFd); // silently close pipe fd
       }
-      if (currentPipeFilename) {
-        fs.unlinkSync(currentPipeFilename); // silently remove old pipe file
+      if (pipeFilename) {
+        fs.unlinkSync(pipeFilename); // silently remove old pipe file
       }
+      pipeFd = undefined;
+      childApp = undefined;
+      pipeFilename = undefined;
       restartAppInternal();
     });
     try {
@@ -213,9 +214,6 @@ function killApp() {
     } catch (error) {
       childApp.kill('SIGKILL');
     }
-    pipeFd = undefined;
-    pipeFilename = undefined;
-    childApp = undefined;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/kmagiera/babel-watch/issues/47

### Post mortem of issue

The issue

- Call `childApp.kill()` and instantly null pipeFd
- `kill` is an asynchronous operation, between us calling it and it happening, the app sends a request that hits this line https://github.com/kmagiera/babel-watch/blob/0bb38ce492b32ae196574a8b36daa79c5a7f61e5/babel-watch.js#L291
- Because we've nulled out the pipeFd, the process crashes

The solution

- Call `childApp.kill()` and only null-out once the process actually exits
- Because we never null out the fd while the process is still alive, we are able to write back to it without crashing node

Worst case scenario with this fix:

- The original process exits and we send the compiled file to the newly spawned process instead. Should have zero side effects and should not crash the process (tho the file transformation is so fast, you should never hit this unless your processor processes node in very delayed ticks)