### PR TITLE
Debounce watch event execution

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -11,8 +11,10 @@ const util = require('util');
 const fork = require('child_process').fork;
 const execSync = require('child_process').execSync;
 const commander = require('commander');
+const debounce = require('lodash.debounce');
 
 const RESTART_COMMAND = 'rs';
+const DEBOUNCE_DURATION = 100; //milliseconds
 
 const program = new commander.Command("babel-watch");
 
@@ -120,9 +122,11 @@ process.on('SIGINT', function() {
   process.exit(1);
 });
 
-watcher.on('change', handleChange);
-watcher.on('add', handleChange);
-watcher.on('unlink', handleChange);
+const debouncedHandleChange = debounce(handleChange, DEBOUNCE_DURATION);
+
+watcher.on('change', debouncedHandleChange);
+watcher.on('add', debouncedHandleChange);
+watcher.on('unlink', debouncedHandleChange);
 
 watcher.on('ready', () => {
   if (!watcherInitialized) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "chokidar": "^1.4.3",
     "commander": "^2.9.0",
+    "lodash.debounce": "^4.0.8",
     "source-map-support": "^0.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
In some scenarios where multiple files are changed nearly simultaneously,
multiple restarts can be attempted. By debouncing, we allow the churn to
cool before attempting a restart.

In reference to kmagiera/babel-watch#37