### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "commander": "^2.9.0",
     "source-map-support": "^0.4.0"
   },
-  "peerDependencies": {
-    "babel-core": "6.5.1 - 6.6.0 || ^6.6.x"
+  "devDependencies": {
+    "babel-core": "^6.26.0"
   },
   "bin": {
     "babel-watch": "./babel-watch.js"


### PR DESCRIPTION
This hasn't been updated in 2 years.

I tried updating the version range, but it turns out babel-watch will in most cases be used as a dev dependency along with babel, and peerDependencies will trigger a warning even if  both of them are in `devDependencies`. To suppress warnings would force users to put babel under `dependencies` which is not an option in most cases. Thus I replaced `peerDependencies` here with `devDependencies`.