### PR TITLE
Handle restart when process has already died

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -304,18 +304,20 @@ function restartAppInternal() {
       const sourceBuf = new Buffer(source || 0);
       const mapBuf = new Buffer(sourceMap ? JSON.stringify(sourceMap) : 0);
       const lenBuf = new Buffer(4);
-      try {
-        lenBuf.writeUInt32BE(sourceBuf.length, 0);
-        fs.writeSync(pipeFd, lenBuf, 0, 4);
-        sourceBuf.length && fs.writeSync(pipeFd, sourceBuf, 0, sourceBuf.length);
+      if (pipeFd) {
+        try {
+          lenBuf.writeUInt32BE(sourceBuf.length, 0);
+          fs.writeSync(pipeFd, lenBuf, 0, 4);
+          sourceBuf.length && fs.writeSync(pipeFd, sourceBuf, 0, sourceBuf.length);
 
-        lenBuf.writeUInt32BE(mapBuf.length, 0);
-        fs.writeSync(pipeFd, lenBuf, 0, 4);
-        mapBuf.length && fs.writeSync(pipeFd, mapBuf, 0, mapBuf.length);
-      } catch (error) {
-        // EPIPE means `pipeFd` has been closed. We can ignore this
-        if (error.code !== 'EPIPE') {
-          throw error;
+          lenBuf.writeUInt32BE(mapBuf.length, 0);
+          fs.writeSync(pipeFd, lenBuf, 0, 4);
+          mapBuf.length && fs.writeSync(pipeFd, mapBuf, 0, mapBuf.length);
+        } catch (error) {
+          // EPIPE means `pipeFd` has been closed. We can ignore this
+          if (error.code !== 'EPIPE') {
+            throw error;
+          }
         }
       }
     });


### PR DESCRIPTION
If the node process has already died (for example, because errors are fatal), you can get into a situation where the restarting fails because it does not detect that the child process has already died. This addresses this case