### PR TITLE
fix(process): don't assume we're the only ones sending process msgs

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -276,6 +276,7 @@ function restartAppInternal() {
   const app = fork(path.resolve(__dirname, 'runner.js'), { execArgv: runnerExecArgv });
 
   app.on('message', (data) => {
+    if (!data || data.event !== 'babel-watch-filename') return;
     const filename = data.filename;
     if (!program.disableAutowatch) {
       // use relative path for watch.add as it would let chokidar reconsile exclude patterns
@@ -304,6 +305,7 @@ function restartAppInternal() {
   });
 
   app.send({
+    event: 'babel-watch-start',
     pipe: pipeFilename,
     args: program.args,
     handleUncaughtExceptions: !program.disableExHandler,

--- a/runner.js
+++ b/runner.js
@@ -41,6 +41,7 @@ function babelWatchLoader(module_, filename, defaultHandler) {
   // require writing native code which usually brings large
   // dependencies to the project and I prefer to avoid that
   process.send({
+    event: 'babel-watch-filename',
     filename: filename,
   });
   const source = readFileFromPipeSync(pipeFd);
@@ -85,6 +86,7 @@ function replaceExtensionHooks(extensions) {
 }
 
 process.on('message', (options) => {
+  if (!options || options.event !== 'babel-watch-start') return;
   replaceExtensionHooks(options.transpileExtensions);
   sourceMapSupport.install({
     environment: 'node',


### PR DESCRIPTION
Fixes crash if the process we're wrapping uses `process.send()`.

Essentially, what can happen is that the wrapped process uses `process.send()` for a test hook or a way to talk to a cluster master, and babel-watch will just happily try to pull `filename` off whatever object was sent and pass it to `path`. This can lead to a nasty error as `path` will refuse to resolve `undefined`.