### PR TITLE
Adds support to provide host/port for the -I (inspect) argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,21 @@ Then use `babel-watch` in your `package.json` in scripts section like this:
 `babel-watch` was made to be compatible with `babel-node` and `nodemon` options. Not all of them are supported yet, here is a short list of supported command line options:
 
 ```
-    -d, --debug [port]             Start debugger on port
-    -B, --debug-brk                Enable debug break mode
-    -I, --inspect                  Enable inspect mode
-    -o, --only [globs]             Matching files will be transpiled
-    -i, --ignore [globs]           Matching files will not be transpiled
-    -e, --extensions [extensions]  List of extensions to hook into [.es6,.js,.es,.jsx]
+    -d, --debug [host AND/OR port]    Start debugger on port
+    -B, --debug-brk                   Enable debug break mode
+    -I, --inspect [host AND/OR port]  Enable inspect mode
+    -K, --inspect-brk                 Enable inspect break mode
+    -o, --only [globs]                Matching files will be transpiled
+    -i, --ignore [globs]              Matching files will not be transpiled
+    -e, --extensions [extensions]     List of extensions to hook into [.es6,.js,.es,.jsx]
     -p, --plugins [string]
     -b, --presets [string]
-    -w, --watch [dir]              Watch directory "dir" or files. Use once for each directory or file to watch
-    -x, --exclude [dir]            Exclude matching directory/files from watcher. Use once for each directory or file.
-    -L, --use-polling              In some filesystems watch events may not work correcly. This option enables "polling" which should mitigate this type of issues
-    -D, --disable-autowatch        Don't automatically start watching changes in files "required" by the program
-    -H, --disable-ex-handler       Disable source-map-enhanced uncaught exception handler. (you may want to use this option in case your app registers a custom uncaught exception handler)
-    -m, --message [string]         Set custom message displayed on restart (default is ">>> RESTARTING <<<")
+    -w, --watch [dir]                 Watch directory "dir" or files. Use once for each directory or file to watch
+    -x, --exclude [dir]               Exclude matching directory/files from watcher. Use once for each directory or file.
+    -L, --use-polling                 In some filesystems watch events may not work correcly. This option enables "polling" which should mitigate this type of issues
+    -D, --disable-autowatch           Don't automatically start watching changes in files "required" by the program
+    -H, --disable-ex-handler          Disable source-map-enhanced uncaught exception handler. (you may want to use this option in case your app registers a custom uncaught exception handler)
+    -m, --message [string]            Set custom message displayed on restart (default is ">>> RESTARTING <<<")
 ```
 
 While the `babel-watch` process is running you may type "rs" and hit return in the terminal to force reload the app.

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -23,9 +23,10 @@ function collect(val, memo) {
   return memo;
 }
 
-program.option('-d, --debug [port]', 'Set debugger port')
+program.option('-d, --debug [host AND/OR port]', 'Set debugger port')
 program.option('-B, --debug-brk', 'Enable debug break mode')
-program.option('-I, --inspect', 'Enable inspect mode')
+program.option('-I, --inspect [host AND/OR port]', 'Enable inspect mode')
+program.option('-K, --inspect-brk', 'Enable inspect break mode')
 program.option('-o, --only [globs]', 'Matching files will be transpiled');
 program.option('-i, --ignore [globs]', 'Matching files will not be transpiled');
 program.option('-e, --extensions [extensions]', 'List of extensions to hook into [.es6,.js,.es,.jsx]');
@@ -292,11 +293,15 @@ function restartAppInternal() {
   }
   // Support for --inspect option
   if (program.inspect) {
-    runnerExecArgv.push('--inspect');
+    runnerExecArgv.push('--inspect=' + program.inspect);
   }
   // Support for --debug-brk
   if(program.debugBrk) {
     runnerExecArgv.push('--debug-brk');
+  }
+  // Support for --inspect-brk
+  if(program.inspectBrk) {
+    runnerExecArgv.push('--inspect-brk');
   }
 
   const app = fork(path.resolve(__dirname, 'runner.js'), { execArgv: runnerExecArgv });


### PR DESCRIPTION
- This is required due to a change in node, [see here](https://github.com/nodejs/node/issues/11591).
- Also adds a new -K argument (inspect-brk).
- Updated README and help text to explain new/updated arguments.