### PR TITLE
Address deprecations.

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -7,13 +7,11 @@ const path = require('path');
 const babel = require('@babel/core');
 const fs = require('fs');
 const os = require('os');
-const util = require('util');
 const fork = require('child_process').fork;
 const execSync = require('child_process').execSync;
 const commander = require('commander');
 const debounce = require('lodash.debounce');
 const isString = require('lodash.isstring');
-const isArray = require('lodash.isarray');
 const isRegExp = require('lodash.isregexp');
 
 const RESTART_COMMAND = 'rs';
@@ -30,7 +28,7 @@ function collect(val, memo) {
 // https://github.com/babel/babel/commit/0df0c696a93889f029982bf36d34346a039b1920
 function regexify(val) {
   if (!val) return new RegExp;
-  if (isArray(val)) val = val.join("|");
+  if (Array.isArray(val)) val = val.join("|");
   if (isString(val)) return new RegExp(val || "");
   if (isRegExp(val)) return val;
   throw new TypeError("illegal type for regexify");
@@ -39,7 +37,7 @@ function regexify(val) {
 function arrayify(val) {
   if (!val) return [];
   if (isString(val)) return (val ? val.split(',') : []);
-  if (isArray(val)) return val;
+  if (Array.isArray(val)) return val;
   throw new TypeError("illegal type for arrayify");
 };
 
@@ -213,7 +211,6 @@ function handleFileLoad(filename, callback) {
 function killApp() {
   if (childApp) {
     const currentPipeFd = pipeFd;
-    const currentPipeFilename = pipeFilename;
 
     let hasRestarted = false;
     const restartOnce = () => {
@@ -299,7 +296,7 @@ function restartAppInternal() {
   const runnerExecArgv = process.execArgv.slice();
   if (program.debug) {
     runnerExecArgv.push(typeof(program.debug) === 'boolean'
-      ? `--debug` 
+      ? `--debug`
       : `--debug=${program.debug}`
     )
   }
@@ -311,14 +308,14 @@ function restartAppInternal() {
   if (program.inspect) {
     // Somehow, the default port (2992) is being passed from the node command line. Wipe it out.
     const inspectArg = typeof(program.inspect) === 'boolean'
-     ? `--inspect` 
+     ? `--inspect`
      : `--inspect=${program.inspect}`
     runnerExecArgv.push(inspectArg);
   }
   // Support for --inspect-brk option
   if (program.inspectBrk) {
-    const inspectBrkArg = typeof(program.inspectBrk) === 'boolean' 
-    ? `--inspect-brk` 
+    const inspectBrkArg = typeof(program.inspectBrk) === 'boolean'
+    ? `--inspect-brk`
     : `--inspect-brk=${program.inspectBrk}`
     runnerExecArgv.push(inspectBrkArg)
   }

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -331,9 +331,9 @@ function restartAppInternal() {
       watcher.add(relativeFilename);
     }
     handleFileLoad(filename, (source, sourceMap) => {
-      const sourceBuf = new Buffer(source || 0);
-      const mapBuf = new Buffer(sourceMap ? JSON.stringify(sourceMap) : 0);
-      const lenBuf = new Buffer(4);
+      const sourceBuf = new Buffer.from(source || '');
+      const mapBuf = new Buffer.from(sourceMap ? JSON.stringify(sourceMap) : 0);
+      const lenBuf = new Buffer.alloc(4);
       if (pipeFd) {
         try {
           lenBuf.writeUInt32BE(sourceBuf.length, 0);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "chokidar": "^1.4.3",
     "commander": "^2.9.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.isarray": "^4.0.0",
     "lodash.isregexp": "^4.0.1",
     "lodash.isstring": "^4.0.1",
     "source-map-support": "^0.4.0"

--- a/runner.js
+++ b/runner.js
@@ -8,7 +8,7 @@ let sources = {};
 let maps = {};
 
 let pipeFd;
-const BUFFER = new Buffer(10 * 1024);
+const BUFFER = new Buffer.alloc(10 * 1024);
 
 // Node by default uses '.js' loader to load all the files with unknown extensions
 const DEFAULT_LOADER = require.extensions['.js'];
@@ -23,7 +23,7 @@ function readLength(fd) {
 
 function readFileFromPipeSync(fd) {
   let length = readLength(fd);
-  let result = new Buffer(0);
+  let result = new Buffer.alloc(0);
   while (length > 0) {
     const newBytes = fs.readSync(fd, BUFFER, 0, Math.min(BUFFER.length, length));
     length -= newBytes;


### PR DESCRIPTION
This addresses the [lodash.isarray](https://www.npmjs.com/package/lodash.isarray) and [Buffer()](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) deprecations.

Tested on Linux with node v10.15.1.