### PR TITLE
Use chokidar@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/kmagiera/babel-watch#readme",
   "dependencies": {
-    "chokidar": "^1.4.3",
+    "chokidar": "^2.0.4",
     "commander": "^2.9.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isregexp": "^4.0.1",


### PR DESCRIPTION
### Change log

* **Breaking:** Upgrade chokidar dependency which requires globs to be more strict and always use POSIX-style slashes because Windows-style slashes are used as escape sequences
* See chokidar change log for more details: https://github.com/paulmillr/chokidar/blob/master/CHANGELOG.md

### Notes for reviewer

* I've set a minimum chokidar version 2.0.4 to match `@babel/cli` https://github.com/babel/babel/blob/master/packages/babel-cli/package.json#L33
* This includes patch for the `braces` vulnerability described in this npm advisory:
https://www.npmjs.com/advisories/786