### PR TITLE
Debounce restartApp instead of handleChange

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -131,11 +131,10 @@ process.on('SIGINT', function() {
   process.exit(0);
 });
 
-const debouncedHandleChange = debounce(handleChange, DEBOUNCE_DURATION);
 
-watcher.on('change', debouncedHandleChange);
-watcher.on('add', debouncedHandleChange);
-watcher.on('unlink', debouncedHandleChange);
+watcher.on('change', handleChange);
+watcher.on('add', handleChange);
+watcher.on('unlink', handleChange);
 
 watcher.on('ready', () => {
   if (!watcherInitialized) {
@@ -158,13 +157,15 @@ stdin.on('data', (data) => {
   }
 });
 
+const debouncedRestartApp = debounce(restartApp, DEBOUNCE_DURATION)
+
 function handleChange(file) {
   const absoluteFile = file.startsWith('/') ? file : path.join(cwd, file);
   delete cache[absoluteFile];
   delete errors[absoluteFile];
 
   // file is in use by the app, let's restart!
-  restartApp();
+  debouncedRestartApp();
 }
 
 function generateTempFilename() {


### PR DESCRIPTION
When handleChange is debounced, sometimes the cache deletion is missed. This Pull Request changes the behaviour slightly by only debouncing the `restartApp` inside `handleChange`.

This is an issue in our containerised (large) development environment, where this patch has been working successfully.