### PR TITLE
Buffer.from should initialize from empty array without sourcemap

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -332,7 +332,7 @@ function restartAppInternal() {
     }
     handleFileLoad(filename, (source, sourceMap) => {
       const sourceBuf = new Buffer.from(source || '');
-      const mapBuf = new Buffer.from(sourceMap ? JSON.stringify(sourceMap) : 0);
+      const mapBuf = new Buffer.from(sourceMap ? JSON.stringify(sourceMap) : []);
       const lenBuf = new Buffer.alloc(4);
       if (pipeFd) {
         try {


### PR DESCRIPTION
I get an error like this when trying to run the latest `HEAD` version of `babel-watch`:

```
throw new TypeError('"value" argument must not be a number');
^

TypeError: "value" argument must not be a number
    at new Buffer.from (buffer.js:186:11)
    at handleFileLoad ([REDACTED]/babel-watch.js:391:22)
    at handleFileLoad ([REDACTED]/babel-watch.js:214:5)
    at ChildProcess.app.on ([REDACTED]/babel-watch.js:389:5)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at emit (internal/child_process.js:772:12)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```