### PR TITLE
Set babel sourcemap option to inline when debug (update of #62)

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -119,7 +119,7 @@ const cwd = process.cwd();
 const only = program.only;
 const ignore = program.ignore;
 const transpileExtensions = program.extensions;
-const debug = Boolean(program.debug || program.debugBrk || program.inspect)
+const debug = Boolean(program.debug || program.debugBrk || program.inspect || program.inspectBrk)
 
 const mainModule = program.args[0];
 if (!mainModule) {

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -119,6 +119,7 @@ const cwd = process.cwd();
 const only = program.only;
 const ignore = program.ignore;
 const transpileExtensions = program.extensions;
+const debug = Boolean(program.debug || program.debugBrk || program.inspect)
 
 const mainModule = program.args[0];
 if (!mainModule) {
@@ -406,6 +407,7 @@ function restartAppInternal() {
     event: 'babel-watch-start',
     pipe: pipeFilename,
     args: program.args,
+    debug: debug,
     handleUncaughtExceptions: !program.disableExHandler,
     transpileExtensions,
   });
@@ -437,7 +439,7 @@ function compile(filename, callback) {
   // Do not process config files since has already been done with the OptionManager
   // calls above and would introduce duplicates.
   opts.babelrc = false;
-  opts.sourceMaps = true;
+  opts.sourceMaps = debug ?  'inline' : true;
   opts.ast = false;
 
   return babel.transformFile(filename, opts, (err, result) => {

--- a/babel-watch.js
+++ b/babel-watch.js
@@ -407,7 +407,7 @@ function restartAppInternal() {
     event: 'babel-watch-start',
     pipe: pipeFilename,
     args: program.args,
-    debug: debug,
+    debug,
     handleUncaughtExceptions: !program.disableExHandler,
     transpileExtensions,
   });

--- a/runner.js
+++ b/runner.js
@@ -90,6 +90,7 @@ process.on('message', (options) => {
   replaceExtensionHooks(options.transpileExtensions);
   sourceMapSupport.install({
     environment: 'node',
+    hookRequire: options.debug,
     handleUncaughtExceptions: !!options.handleUncaughtExceptions,
     retrieveSourceMap(filename) {
       const map = maps && maps[filename];


### PR DESCRIPTION
This PR is an update of #62.

I rebased the changes on top of `master` and I fixed the conflicts that prevented the merge.
I also added `inspectBrk` as it was missing from the list.

All credit goes to @zaaack.