### PR TITLE
fix(runner): prevent infinite loop when reading 0 bytes

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -18,10 +18,10 @@ const DEFAULT_LOADER = reqExtensions['.js'];
 
 function readLength(fd) {
   let bytes = 0;
-  while (typeof bytes === 'number' && bytes !== 4) {
+  do {
     // $FlowIgnore position can be null
     bytes = fs.readSync(fd, BUFFER, 0, 4, null);
-  }
+  } while (typeof bytes === 'number' && bytes !== 4 && bytes !== 0);
   return BUFFER.readUInt32BE(0);
 }
 


### PR DESCRIPTION
Fixes an issue where the runner.js process can loop indefinitely if the pipe is closed.
Happens intermittently but frequently enough on our codebase to be a real nuisance.