### PR TITLE
Bump signal-exit from legacy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isregexp": "^4.0.1",
     "lodash.isstring": "^4.0.1",
-    "signal-exit": "^2.1.2",
+    "signal-exit": "^3.0.7",
     "source-map-support": "^0.5.19",
     "string-argv": "^0.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,10 +437,10 @@ semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-signal-exit@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"
-  integrity sha512-Hjt8MofEmj5vFgJ5vnad1V8msp7lJg/gdBP7fOmEnlgeUYkg9ntdQEzBPMc0sjJf6MVkBALNSo/KvfVn34MIwQ==
+signal-exit@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 source-map-support@^0.5.19:
   version "0.5.19"


### PR DESCRIPTION
Got the wrong version accidentally. ^2.x.x is nearly not used anymore, while ^3.x.x is

Bumps #136 