### PR TITLE
Fix: Add error forwarding from babel to stderr (#143)

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -423,34 +423,39 @@ function restartAppInternal() {
   });
 
   app.on('message', (data) => {
-    if (!data || data.event !== 'babel-watch-filename') return;
-    const filename = data.filename;
-    if (!program.disableAutowatch) {
-      // use relative path for watch.add as it would let chokidar reconsile exclude patterns
-      const relativeFilename = path.relative(cwd, filename);
-      watcher.add(relativeFilename);
-    }
-    handleFileLoad(filename, (source, sourceMap) => {
-      const sourceBuf = Buffer.from(source || '');
-      const mapBuf = Buffer.from(sourceMap ? JSON.stringify(sourceMap) : []);
-      const lenBuf = Buffer.alloc(4);
-      if (pipeFd) {
-        try {
-          lenBuf.writeUInt32BE(sourceBuf.length, 0);
-          fs.writeSync(pipeFd, lenBuf, 0, 4);
-          sourceBuf.length && fs.writeSync(pipeFd, sourceBuf, 0, sourceBuf.length);
+    try {
+      if (!data || data.event !== 'babel-watch-filename') return;
+      const filename = data.filename;
+      if (!program.disableAutowatch) {
+        // use relative path for watch.add as it would let chokidar reconsile exclude patterns
+        const relativeFilename = path.relative(cwd, filename);
+        watcher.add(relativeFilename);
+      }
+      handleFileLoad(filename, (source, sourceMap) => {
+        const sourceBuf = Buffer.from(source || '');
+        const mapBuf = Buffer.from(sourceMap ? JSON.stringify(sourceMap) : []);
+        const lenBuf = Buffer.alloc(4);
+        if (pipeFd) {
+          try {
+            lenBuf.writeUInt32BE(sourceBuf.length, 0);
+            fs.writeSync(pipeFd, lenBuf, 0, 4);
+            sourceBuf.length && fs.writeSync(pipeFd, sourceBuf, 0, sourceBuf.length);
 
-          lenBuf.writeUInt32BE(mapBuf.length, 0);
-          fs.writeSync(pipeFd, lenBuf, 0, 4);
-          mapBuf.length && fs.writeSync(pipeFd, mapBuf, 0, mapBuf.length);
-        } catch (error) {
-          // EPIPE means `pipeFd` has been closed. We can ignore this
-          if (error.code !== 'EPIPE') {
-            throw error;
+            lenBuf.writeUInt32BE(mapBuf.length, 0);
+            fs.writeSync(pipeFd, lenBuf, 0, 4);
+            mapBuf.length && fs.writeSync(pipeFd, mapBuf, 0, mapBuf.length);
+          } catch (error) {
+            // EPIPE means `pipeFd` has been closed. We can ignore this
+            if (error.code !== 'EPIPE') {
+              throw error;
+            }
           }
         }
-      }
-    });
+      });
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
   });
 
   app.on('exit', (code, signal) => {


### PR DESCRIPTION
Same check list :)
- [x] Verify that locally published package works
- [x] Verify that ctrl+c stops babel-watch
- [x] Verify that underlying app crash is handled properly
- [x] Verify auto restart after changing files works
- [x] Verify manual restart via "rs" works