### PR TITLE
#147 Fix parse freesing on ignored files, catch and rethrow exception…

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -532,7 +532,7 @@ function restartAppInternal() {
         watcher.add(relativeFilename);
       }
       const [source, sourceMap] = await handleFileLoad(filename);
-      if (!source) return; // ignored or printed error
+
       const sourceBuf = Buffer.from(source || "");
       const mapBuf = Buffer.from(sourceMap ? JSON.stringify(sourceMap) : []);
       const lenBuf = Buffer.alloc(4);

--- a/runner.js
+++ b/runner.js
@@ -4,6 +4,10 @@ const path = require("path");
 const fs = require("fs");
 const sourceMapSupport = require("source-map-support");
 
+process.on("uncaughtException", err => {
+  throw err;
+});
+
 let sources = {};
 let maps = {};
 


### PR DESCRIPTION
- Fix parse freezing on ignored files (For example .json), after latest refactoring;
- Catch and rethrow exceptions during babelified code execution;